### PR TITLE
Fix issue with url gen. when the host is localhost

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ def get_url(route):
     url = url_for(
         route,
         _external=True,
-        _scheme='http' if request.host.startswith('127.0.0.1') else 'https'
+        _scheme='http' if (request.host.startswith('127.0.0.1') or request.host is 'localhost') else 'https'
     )
 
     return url


### PR DESCRIPTION
The application was unable to generate proper URL scheme when the host name is localhost. This is fixed by not only checking for 127.0.0.1 but also for the host name localhost, and setting the URL scheme to HTTP.
